### PR TITLE
Update wp_bootstrap_pagination.php

### DIFF
--- a/wp_bootstrap_pagination.php
+++ b/wp_bootstrap_pagination.php
@@ -4,12 +4,13 @@
  */
 
 function wp_bootstrap_pagination( $args = array() ) {
-    
     $defaults = array(
         'range'           => 4,
         'custom_query'    => FALSE,
         'previous_string' => __( 'Previous', 'text-domain' ),
         'next_string'     => __( 'Next', 'text-domain' ),
+        'last_string'     => __( 'Last', 'text-domain' ),
+        'first_string'    => __( 'First', 'text-domain' ),
         'before_output'   => '<div class="post-nav"><ul class="pager">',
         'after_output'    => '</ul></div>'
     );
@@ -25,10 +26,8 @@ function wp_bootstrap_pagination( $args = array() ) {
     $count = (int) $args['custom_query']->max_num_pages;
     $page  = intval( get_query_var( 'paged' ) );
     $ceil  = ceil( $args['range'] / 2 );
-    
     if ( $count <= 1 )
         return FALSE;
-    
     if ( !$page )
         $page = 1;
     
@@ -54,10 +53,10 @@ function wp_bootstrap_pagination( $args = array() ) {
     
     $firstpage = esc_attr( get_pagenum_link(1) );
     if ( $firstpage && (1 != $page) )
-        $echo .= '<li class="previous"><a href="' . $firstpage . '">' . __( 'First', 'text-domain' ) . '</a></li>';
+        $echo .= '<li class="previous"><a href="' . $firstpage . '">' . $args['first_string'] . '</a></li>';
 
     if ( $previous && (1 != $page) )
-        $echo .= '<li><a href="' . $previous . '" title="' . __( 'previous', 'text-domain') . '">' . $args['previous_string'] . '</a></li>';
+        $echo .= '<li><a href="' . $previous . '" title="' . $args['previous_string'] . '">' . $args['previous_string'] . '</a></li>';
     
     if ( !empty($min) && !empty($max) ) {
         for( $i = $min; $i <= $max; $i++ ) {
@@ -72,11 +71,11 @@ function wp_bootstrap_pagination( $args = array() ) {
     $next = intval($page) + 1;
     $next = esc_attr( get_pagenum_link($next) );
     if ($next && ($count != $page) )
-        $echo .= '<li><a href="' . $next . '" title="' . __( 'next', 'text-domain') . '">' . $args['next_string'] . '</a></li>';
+        $echo .= '<li><a href="' . $next . '" title="' . $args['next_string'] . '">' . $args['next_string'] . '</a></li>';
     
     $lastpage = esc_attr( get_pagenum_link($count) );
     if ( $lastpage ) {
-        $echo .= '<li class="next"><a href="' . $lastpage . '">' . __( 'Last', 'text-domain' ) . '</a></li>';
+        $echo .= '<li class="next"><a href="' . $lastpage . '">' . $args['last_string'] . '</a></li>';
     }
 
     if ( isset($echo) )


### PR DESCRIPTION
Added suport for setting up first and last as text strings. (because the original didn't have that)
